### PR TITLE
New scanner engine for verify map

### DIFF
--- a/OMSI-Tools.pro
+++ b/OMSI-Tools.pro
@@ -53,6 +53,7 @@ SOURCES += \
     OTBackend/OCC/OCViewable.cpp \
     OTBackend/OCC/OCWeather.cpp \
     OTBackend/OTLogger.cpp \
+    OTBackend/OTMapScanner.cpp \
     OTModules/OTGeneric/wfeedback.cpp \
     OTModules/OTGeneric/wfirstsetup.cpp \
     OTModules/OTGeneric/wpreferences.cpp \
@@ -145,6 +146,7 @@ HEADERS += \
     OTBackend/OTExternal.h \
     OTBackend/OTGlobal.h \
     OTBackend/OTLogger.h \
+    OTBackend/OTMapScanner.h \
     OTBackend/OTOmsiFileHandler.h \
     OTBackend/OTOmsiFileHandler_models.h \
     OTModules/OTGeneric/wfeedback.h \

--- a/OTBackend/OTMapScanner.cpp
+++ b/OTBackend/OTMapScanner.cpp
@@ -82,6 +82,10 @@ void OTMapChecker::run() {
     std::sort(_missingSplines.begin(),        _missingSplines.end());
 }
 
+QString OTMapChecker::omsiDir() const {
+    return _omsiDir;
+}
+
 void OTMapChecker::setOmsiDir(const QString &str) {
     _omsiDir = str;
 }
@@ -157,6 +161,7 @@ void OTMapScanner::run() {
     _allTiles.clear();
     _missingTiles.clear();
     scanGlobal();
+    scanTextures();
     scanParkLists();
     scanHumans();
 
@@ -195,10 +200,26 @@ void OTMapScanner::scanGlobal() {
             s.readLine();
             s.readLine();
             _allTiles << s.readLine();
+        } else if(line == "[groundtex]") {
+            QString tex1 = s.readLine();
+            QString tex2 = s.readLine();
+
+            if(!_allTextures.contains(tex1))
+                _allTextures << tex1;
+            if(!_allTextures.contains(tex2))
+                _allTextures << tex2;
         }
     }
 
     f.close();
+}
+
+void OTMapScanner::scanTextures() {
+    QString omsiDir = _checker->omsiDir();
+    for(QString current : _allTextures) {
+        if(!QFile::exists(omsiDir + "/" + current) && !_missingTextures.contains(current))
+            _missingTextures << current;
+    }
 }
 
 void OTMapScanner::scanParkLists() {
@@ -289,14 +310,30 @@ QStringList OTMapScanner::allTiles() const {
     return _allTiles;
 }
 
+QStringList OTMapScanner::allTextures() const {
+    return _allTextures;
+}
+
 QStringList OTMapScanner::missingTiles() const {
     return _missingTiles;
+}
+
+QStringList OTMapScanner::missingTextures() const {
+    return _missingTextures;
 }
 
 int OTMapScanner::allTilesCout() const {
     return _allTiles.count();
 }
 
+int OTMapScanner::allTexturesCount() const {
+    return _allTextures.count();
+}
+
 int OTMapScanner::missingTilesCount() {
     return _missingTiles.count();
+}
+
+int OTMapScanner::missingTexturesCount() const {
+    return _missingTextures.count();
 }

--- a/OTBackend/OTMapScanner.cpp
+++ b/OTBackend/OTMapScanner.cpp
@@ -132,6 +132,7 @@ void OTMapScanner::run() {
     _allTiles.clear();
     _missingTiles.clear();
     scanGlobal();
+    scanParkLists();
 
     int tileCount = _allTiles.count();
     emit initActionCount(tileCount);
@@ -172,6 +173,28 @@ void OTMapScanner::scanGlobal() {
     }
 
     f.close();
+}
+
+void OTMapScanner::scanParkLists() {
+    int i = 0;
+
+    while(true) {
+        QString indexStr = i != 0 ? "_" + QString::number(i) : "";
+        QString path = _mapDir + "/parklist_p" + indexStr + ".txt";
+        QFile f(path);
+        if(!f.exists())
+            break;
+
+        f.open(QFile::ReadOnly);
+        QTextStream s(&f);
+        QStringList list;
+        while(!s.atEnd()) {
+            list << s.readLine();
+        }
+        f.close();
+        _checker->addToQueue(list);
+        i++;
+    }
 }
 
 void OTMapScanner::scanTile(const QString &filename) {

--- a/OTBackend/OTMapScanner.cpp
+++ b/OTBackend/OTMapScanner.cpp
@@ -52,16 +52,18 @@ void OTMapChecker::run() {
                     continue;
 
                 if(!QFile::exists(_omsiDir + "/" + file)) {
-                    if(type == 0)
-                        _missingSceneryobjects << file;
-                    else
-                        _missingSplines << file;
+                    switch(type) {
+                        case 0: _missingSceneryobjects << file; break;
+                        case 1: _missingSplines        << file; break;
+                        default: break;
+                    }
                 }
 
-                if(type == 0)
-                    _allSceneryobjects << file;
-                else
-                    _allSplines << file;
+                switch(type) {
+                case 0: _allSceneryobjects << file; break;
+                case 1: _allSplines        << file; break;
+                default: break;
+                }
             }
         }
     }

--- a/OTBackend/OTMapScanner.cpp
+++ b/OTBackend/OTMapScanner.cpp
@@ -13,7 +13,7 @@
 #include "OTMapScanner.h"
 
 OTMapChecker::OTMapChecker(QObject *parent) :
-    OTMapScannerAbstract(parent),
+    QThread(parent),
     _finish(false) {
 }
 
@@ -177,7 +177,7 @@ int OTMapChecker::missingVehiclesCount() const {
 // ------------------------------------------------------------------------
 
 OTMapScanner::OTMapScanner(QObject *parent, OTMapChecker *checker) :
-    OTMapScannerAbstract(parent),
+    QThread(parent),
     _checker(checker)
 {}
 

--- a/OTBackend/OTMapScanner.cpp
+++ b/OTBackend/OTMapScanner.cpp
@@ -191,7 +191,11 @@ void OTMapScanner::scanParkLists() {
             break;
         }
 
-        f.open(QFile::ReadOnly);
+        if(!f.open(QFile::ReadOnly)) {
+            qWarning() << "Could not open " << path.remove(_mapDir);
+            break;
+        }
+
         QTextStream s(&f);
         QStringList list;
         while(!s.atEnd()) {

--- a/OTBackend/OTMapScanner.cpp
+++ b/OTBackend/OTMapScanner.cpp
@@ -182,8 +182,12 @@ void OTMapScanner::scanParkLists() {
         QString indexStr = i != 0 ? "_" + QString::number(i) : "";
         QString path = _mapDir + "/parklist_p" + indexStr + ".txt";
         QFile f(path);
-        if(!f.exists())
+        if(!f.exists() && i != 0)
             break;
+        else if(!f.exists()) {
+            qWarning() << "parklist_p.txt not found!";
+            break;
+        }
 
         f.open(QFile::ReadOnly);
         QTextStream s(&f);

--- a/OTBackend/OTMapScanner.cpp
+++ b/OTBackend/OTMapScanner.cpp
@@ -21,8 +21,10 @@ void OTMapChecker::run() {
     _finish = false;
     _allSceneryobjects.clear();
     _allSplines.clear();
+    _allHumans.clear();
     _missingSceneryobjects.clear();
     _missingSplines.clear();
+    _missingHumans.clear();
 
     while (true) {
         QMutexLocker locker(&_mutex);
@@ -159,7 +161,9 @@ OTMapScanner::OTMapScanner(QObject *parent, OTMapChecker *checker) :
 
 void OTMapScanner::run() {
     _allTiles.clear();
+    _allTextures.clear();
     _missingTiles.clear();
+    _missingTextures.clear();
     scanGlobal();
     scanTextures();
     scanParkLists();

--- a/OTBackend/OTMapScanner.cpp
+++ b/OTBackend/OTMapScanner.cpp
@@ -1,0 +1,223 @@
+// TODO: Advanced verifying:
+/*
+ * SCO:
+    - Mesh
+    - Materials
+    - Texturen
+    - Varlists
+
+ * SLI:
+    - Texturen
+
+*/
+#include "OTMapScanner.h"
+
+OTMapChecker::OTMapChecker(QObject *parent) :
+    OTMapScannerAbstract(parent),
+    _finish(false) {
+}
+
+void OTMapChecker::run() {
+    _finish = false;
+    _allSceneryobjects.clear();
+    _allSplines.clear();
+    _missingSceneryobjects.clear();
+    _missingSplines.clear();
+
+    while (true) {
+        QMutexLocker locker(&_mutex);
+        if (_queue.isEmpty()) {
+            if (_finish) break;
+            _dataAvailable.wait(&_mutex);
+        }
+        if (!_queue.isEmpty()) {
+            QStringList files = _queue.dequeue();
+            locker.unlock();
+
+            for(QString file : files) {
+                int type; //0 = Sceneryobject / 1 = Spline
+                if(file.endsWith(".sco")) {
+                    type = 0;
+                } else if(file.endsWith(".sli")) {
+                    type = 1;
+                } else {
+                    qWarning() << "Unkown file type" << file;
+                    continue;
+                }
+
+                if(type == 0 && _allSceneryobjects.contains(file))
+                    continue;
+
+                if(type == 1 && _allSplines.contains(file))
+                    continue;
+
+                if(!QFile::exists(_omsiDir + "/" + file)) {
+                    if(type == 0)
+                        _missingSceneryobjects << file;
+                    else
+                        _missingSplines << file;
+                }
+
+                if(type == 0)
+                    _allSceneryobjects << file;
+                else
+                    _allSplines << file;
+            }
+        }
+    }
+
+    // process stuff
+    std::sort(_allSceneryobjects.begin(),     _allSceneryobjects.end());
+    std::sort(_allSplines.begin(),             _allSplines.end());
+    std::sort(_missingSceneryobjects.begin(), _missingSceneryobjects.end());
+    std::sort(_missingSplines.begin(),        _missingSplines.end());
+}
+
+void OTMapChecker::setOmsiDir(const QString &str) {
+    _omsiDir = str;
+}
+
+void OTMapChecker::addToQueue(const QStringList &list) {
+    QMutexLocker locker(&_mutex);
+    _queue.enqueue(list);
+    _dataAvailable.wakeOne();
+}
+
+void OTMapChecker::setFinished() {
+    QMutexLocker locker(&_mutex);
+    _finish = true;
+    _dataAvailable.wakeOne();
+}
+
+QStringList OTMapChecker::allSceneryobjects() const {
+    return _allSceneryobjects;
+}
+
+QStringList OTMapChecker::allSplines() const {
+    return _allSplines;
+}
+
+QStringList OTMapChecker::missingSceneryobjects() const {
+    return _missingSceneryobjects;
+}
+
+QStringList OTMapChecker::missingSplines() const {
+    return _missingSplines;
+}
+
+int OTMapChecker::allSceneryobjectsCount() const {
+    return _allSceneryobjects.count();
+}
+
+int OTMapChecker::allSplinesCount() const {
+    return _allSplines.count();
+}
+
+int OTMapChecker::missingSceneryobjectsCount() const {
+    return _missingSceneryobjects.count();
+}
+
+int OTMapChecker::missingSplinesCount() const {
+    return _missingSplines.count();
+}
+
+// ------------------------------------------------------------------------
+
+OTMapScanner::OTMapScanner(QObject *parent, OTMapChecker *checker) :
+    OTMapScannerAbstract(parent),
+    _checker(checker)
+{}
+
+void OTMapScanner::run() {
+    _allTiles.clear();
+    _missingTiles.clear();
+    scanGlobal();
+
+    int tileCount = _allTiles.count();
+    emit initActionCount(tileCount);
+    QString totalString = " /";
+
+    int i = 1;
+    for(QString str : _allTiles) {
+        emit statusUpdate(i, tr("Read tile %1 of %2").arg(QString::number(i), QString::number(tileCount)));
+        scanTile(str);
+        i++;
+    }
+
+    _checker->setFinished();
+}
+
+void OTMapScanner::setMapDir(const QString &str) {
+    _mapDir = str;
+}
+
+void OTMapScanner::scanGlobal() {
+    QFile f(_mapDir + "/global.cfg");
+    if(!f.exists())
+        return;
+
+    if(!f.open(QFile::ReadOnly))
+        return;
+
+    QTextStream s(&f);
+
+    while(!s.atEnd()) {
+        QString line = s.readLine();
+
+        if(line == "[map]") {
+            s.readLine();
+            s.readLine();
+            _allTiles << s.readLine();
+        }
+    }
+
+    f.close();
+}
+
+void OTMapScanner::scanTile(const QString &filename) {
+    QStringList fileList;
+
+    QFile f(_mapDir + "/" + filename);
+    if(!f.exists() || !f.open(QFile::ReadOnly)) {
+        _missingTiles << filename;
+        return;
+    }
+
+    QTextStream s(&f);
+
+    while(!s.atEnd()) {
+        QString line = s.readLine();
+
+        if(line == "[object]" || line == "[attachObj]" || line == "[splineAttachement]" || line == "[spline]" || line == "[spline_h]") {
+            s.readLine();
+            fileList << s.readLine();
+        }
+
+        if(line == "[splineAttachement_repeater]") {
+            s.readLine();
+            s.readLine();
+            s.readLine();
+            fileList << s.readLine();
+        }
+    }
+
+    f.close();
+    fileList.removeDuplicates();
+    _checker->addToQueue(fileList);
+}
+
+QStringList OTMapScanner::allTiles() const {
+    return _allTiles;
+}
+
+QStringList OTMapScanner::missingTiles() const {
+    return _missingTiles;
+}
+
+int OTMapScanner::allTilesCout() const {
+    return _allTiles.count();
+}
+
+int OTMapScanner::missingTilesCount() {
+    return _missingTiles.count();
+}

--- a/OTBackend/OTMapScanner.h
+++ b/OTBackend/OTMapScanner.h
@@ -11,20 +11,7 @@
 #include <QFile>
 #include <QTextStream>
 
-class OTMapScannerAbstract : public QThread
-{
-    Q_OBJECT
-public:
-    explicit OTMapScannerAbstract(QObject *parent) : QThread(parent) {}
-    void run() override = 0;
-
-signals:
-    void initActionCount(int);
-    void statusUpdate(int, QString);
-private:
-};
-
-class OTMapChecker : public OTMapScannerAbstract
+class OTMapChecker : public QThread
 {
     Q_OBJECT
 public:
@@ -71,7 +58,7 @@ private:
     QStringList _missingVehicles;
 };
 
-class OTMapScanner : public OTMapScannerAbstract
+class OTMapScanner : public QThread
 {
     Q_OBJECT
 public:
@@ -95,6 +82,10 @@ public:
     int allTexturesCount() const;
     int missingTilesCount();
     int missingTexturesCount() const;
+
+signals:
+    void initActionCount(int);
+    void statusUpdate(int, QString);
 
 private:
     OTMapChecker *_checker;

--- a/OTBackend/OTMapScanner.h
+++ b/OTBackend/OTMapScanner.h
@@ -30,6 +30,7 @@ public:
     explicit OTMapChecker(QObject *parent);
     void run() override;
 
+    QString omsiDir() const;
     void setOmsiDir(const QString &);
     void addToQueue(const QStringList &);
     void setFinished();
@@ -72,21 +73,28 @@ public:
     void setMapDir(const QString &);
 
     void scanGlobal();
+    void scanTextures();
     void scanParkLists();
     void scanHumans();
     void scanTile(const QString &filename);
 
     QStringList allTiles() const;
+    QStringList allTextures() const;
     QStringList missingTiles() const;
+    QStringList missingTextures() const;
 
     int allTilesCout() const;
+    int allTexturesCount() const;
     int missingTilesCount();
+    int missingTexturesCount() const;
 
 private:
     OTMapChecker *_checker;
     QString _mapDir;
     QStringList _allTiles;
+    QStringList _allTextures;
     QStringList _missingTiles;
+    QStringList _missingTextures;
 };
 
 

--- a/OTBackend/OTMapScanner.h
+++ b/OTBackend/OTMapScanner.h
@@ -1,0 +1,86 @@
+#ifndef OTMAPSCANNER_H
+#define OTMAPSCANNER_H
+
+#include <QThread>
+#include <QFile>
+#include <QMutex>
+#include <QQueue>
+#include <QWaitCondition>
+#include <QDebug>
+#include <QFile>
+#include <QTextStream>
+
+class OTMapScannerAbstract : public QThread
+{
+    Q_OBJECT
+public:
+    explicit OTMapScannerAbstract(QObject *parent) : QThread(parent) {}
+    void run() override = 0;
+
+signals:
+    void initActionCount(int);
+    void statusUpdate(int, QString);
+private:
+};
+
+class OTMapChecker : public OTMapScannerAbstract
+{
+    Q_OBJECT
+public:
+    explicit OTMapChecker(QObject *parent);
+    void run() override;
+
+    void setOmsiDir(const QString &);
+    void addToQueue(const QStringList &);
+    void setFinished();
+
+    QStringList allSceneryobjects() const;
+    QStringList allSplines() const;
+    QStringList missingSceneryobjects() const;
+    QStringList missingSplines() const;
+
+    int allSceneryobjectsCount() const;
+    int allSplinesCount() const;
+    int missingSceneryobjectsCount() const;
+    int missingSplinesCount() const;
+
+private:
+    QString _omsiDir;
+    QQueue<QStringList> _queue;
+    QMutex _mutex;
+    QWaitCondition _dataAvailable;
+    bool _finish;
+
+    QStringList _allSceneryobjects;
+    QStringList _allSplines;
+    QStringList _missingSceneryobjects;
+    QStringList _missingSplines;
+};
+
+class OTMapScanner : public OTMapScannerAbstract
+{
+    Q_OBJECT
+public:
+    explicit OTMapScanner(QObject *parent, OTMapChecker *checker);
+    void run() override;
+    void setMapDir(const QString &);
+
+    void scanGlobal();
+    void scanTile(const QString &filename);
+
+    QStringList allTiles() const;
+    QStringList missingTiles() const;
+
+    int allTilesCout() const;
+    int missingTilesCount();
+
+private:
+    OTMapChecker *_checker;
+    QString _mapDir;
+    QStringList _allTiles;
+    QStringList _missingTiles;
+};
+
+
+
+#endif // OTMAPSCANNER_H

--- a/OTBackend/OTMapScanner.h
+++ b/OTBackend/OTMapScanner.h
@@ -66,6 +66,7 @@ public:
     void setMapDir(const QString &);
 
     void scanGlobal();
+    void scanParkLists();
     void scanTile(const QString &filename);
 
     QStringList allTiles() const;

--- a/OTBackend/OTMapScanner.h
+++ b/OTBackend/OTMapScanner.h
@@ -3,6 +3,7 @@
 
 #include <QThread>
 #include <QFile>
+#include <QDir>
 #include <QMutex>
 #include <QQueue>
 #include <QWaitCondition>

--- a/OTBackend/OTMapScanner.h
+++ b/OTBackend/OTMapScanner.h
@@ -36,13 +36,17 @@ public:
 
     QStringList allSceneryobjects() const;
     QStringList allSplines() const;
+    QStringList allHumans() const;
     QStringList missingSceneryobjects() const;
     QStringList missingSplines() const;
+    QStringList missingHumans() const;
 
     int allSceneryobjectsCount() const;
     int allSplinesCount() const;
+    int allHumansCount() const;
     int missingSceneryobjectsCount() const;
     int missingSplinesCount() const;
+    int missingHumansCount();
 
 private:
     QString _omsiDir;
@@ -55,6 +59,8 @@ private:
     QStringList _allSplines;
     QStringList _missingSceneryobjects;
     QStringList _missingSplines;
+    QStringList _allHumans;
+    QStringList _missingHumans;
 };
 
 class OTMapScanner : public OTMapScannerAbstract
@@ -67,6 +73,7 @@ public:
 
     void scanGlobal();
     void scanParkLists();
+    void scanHumans();
     void scanTile(const QString &filename);
 
     QStringList allTiles() const;

--- a/OTBackend/OTMapScanner.h
+++ b/OTBackend/OTMapScanner.h
@@ -38,16 +38,20 @@ public:
     QStringList allSceneryobjects() const;
     QStringList allSplines() const;
     QStringList allHumans() const;
+    QStringList allVehicles() const;
     QStringList missingSceneryobjects() const;
     QStringList missingSplines() const;
     QStringList missingHumans() const;
+    QStringList missingVehicles() const;
 
     int allSceneryobjectsCount() const;
     int allSplinesCount() const;
     int allHumansCount() const;
+    int allVehiclesCount() const;
     int missingSceneryobjectsCount() const;
     int missingSplinesCount() const;
     int missingHumansCount();
+    int missingVehiclesCount() const;
 
 private:
     QString _omsiDir;
@@ -58,10 +62,12 @@ private:
 
     QStringList _allSceneryobjects;
     QStringList _allSplines;
+    QStringList _allHumans;
+    QStringList _allVehicles;
     QStringList _missingSceneryobjects;
     QStringList _missingSplines;
-    QStringList _allHumans;
     QStringList _missingHumans;
+    QStringList _missingVehicles;
 };
 
 class OTMapScanner : public OTMapScannerAbstract
@@ -76,6 +82,7 @@ public:
     void scanTextures();
     void scanParkLists();
     void scanHumans();
+    void scanAiList();
     void scanTile(const QString &filename);
 
     QStringList allTiles() const;

--- a/OTModules/wVerifyMap/wdgoverviewtile.cpp
+++ b/OTModules/wVerifyMap/wdgoverviewtile.cpp
@@ -19,7 +19,7 @@ void wdgOverviewTile::setTotal(int count)
     switch (type)
     {
         case Tile: ui->lblTotal->setText(tr("%n tile(s)", "", count)); break;
-        case Sceneryobject: ui->lblTotal->setText(tr("%n sceneryobjec(ts)", "", count)); break;
+        case Sceneryobject: ui->lblTotal->setText(tr("%n sceneryobject(s)", "", count)); break;
         case Spline: ui->lblTotal->setText(tr("%n spline(s)", "", count)); break;
         case Vehicle: ui->lblTotal->setText(tr("%n vehicle(s)", "", count)); break;
         case Human: ui->lblTotal->setText(tr("%n human(s)", "", count)); break;

--- a/OTModules/wVerifyMap/wdgtab.cpp
+++ b/OTModules/wVerifyMap/wdgtab.cpp
@@ -18,7 +18,7 @@ wdgTab::~wdgTab()
 
 void wdgTab::clear()
 {
-    existing.clear();
+    all.clear();
     missing.clear();
 
     ui->lwgAll->clear();
@@ -32,7 +32,7 @@ void wdgTab::add(QStringList items, bool isMissing)
 {
     isApplied = false;
     if (isMissing) missing << items;
-    else existing << items;
+    else all << items;
 }
 
 void wdgTab::apply()
@@ -42,8 +42,6 @@ void wdgTab::apply()
     ui->lwgMissing->sortItems();
 
     ui->lwgAll->clear();
-    QStringList all = QStringList(existing + missing);
-    all.removeDuplicates();
     ui->lwgAll->addItems(all);
     ui->lwgAll->sortItems();
     isApplied = true;
@@ -61,7 +59,7 @@ void wdgTab::setName(QString name)
 OTVerificationOverviewData wdgTab::getData()
 {
     if (!isApplied) qFatal() << "Cannot get data from an unapplied object!";
-    return OTVerificationOverviewData(missing.count(), existing.count());
+    return OTVerificationOverviewData(missing.count(), all.count());
 }
 
 void wdgTab::on_btnSearchForMissingElements_clicked()
@@ -72,7 +70,7 @@ void wdgTab::on_btnSearchForMissingElements_clicked()
 
 void wdgTab::on_btnCopySelectedElements_clicked()
 {
-    if (ui->lwgMissing->selectedItems().isEmpty()) copy(ui->twgItems->currentIndex() ? missing : existing);
+    if (ui->lwgMissing->selectedItems().isEmpty()) copy(ui->twgItems->currentIndex() ? missing : all);
     else copy(ui->twgItems->currentIndex() ? ui->lwgMissing->selectedItems() : ui->lwgAll->selectedItems());
 }
 

--- a/OTModules/wVerifyMap/wdgtab.cpp
+++ b/OTModules/wVerifyMap/wdgtab.cpp
@@ -31,6 +31,7 @@ void wdgTab::clear()
 void wdgTab::add(QStringList items, bool isMissing)
 {
     isApplied = false;
+    items.replaceInStrings("/", "\\");
     if (isMissing) missing << items;
     else all << items;
 }

--- a/OTModules/wVerifyMap/wdgtab.h
+++ b/OTModules/wVerifyMap/wdgtab.h
@@ -61,7 +61,7 @@ private:
     OTMiscellaneous misc;
     wContentSearch* WCONTENTSEARCH;
 
-    QStringList existing, missing;
+    QStringList all, missing;
 
     bool isApplied = false;
 

--- a/OTModules/wVerifyMap/wdgtab.ui
+++ b/OTModules/wVerifyMap/wdgtab.ui
@@ -37,7 +37,7 @@
       </property>
       <widget class="QWidget" name="tabAll">
        <attribute name="title">
-        <string>all</string>
+        <string notr="true">all</string>
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout">
         <item>
@@ -109,7 +109,7 @@
        </layout>
       </widget>
      </widget>
-     <widget class="QWidget" name="">
+     <widget class="QWidget" name="layoutWidget">
       <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0">
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_3">

--- a/OTModules/wVerifyMap/wverifymap.cpp
+++ b/OTModules/wVerifyMap/wverifymap.cpp
@@ -249,7 +249,6 @@ void wVerifyMap::loadMapList()
         if (mapList[i].second == lastMap)
         {
             ui->cobxMapName->setCurrentIndex(i);
-            i = mapList.size();
         }
     }
     mapListSetupFinished = true;

--- a/OTModules/wVerifyMap/wverifymap.cpp
+++ b/OTModules/wVerifyMap/wverifymap.cpp
@@ -26,11 +26,8 @@ wVerifyMap::wVerifyMap(QWidget *parent) :
     connect(_scanner, &QThread::finished, this, &wVerifyMap::onScannerFinished);
     connect(_checker, &QThread::finished, this, &wVerifyMap::onCheckerFinished);
 
-    connect(_scanner, &OTMapScannerAbstract::initActionCount, ui->pgbProgress, &QProgressBar::setMaximum);
-    connect(_checker, &OTMapScannerAbstract::initActionCount, ui->pgbProgress, &QProgressBar::setMaximum);
-
-    connect(_scanner, &OTMapScannerAbstract::statusUpdate, this, &wVerifyMap::onStatusUpdate);
-    connect(_checker, &OTMapScannerAbstract::statusUpdate, this, &wVerifyMap::onStatusUpdate);
+    connect(_scanner, &OTMapScanner::initActionCount, ui->pgbProgress, &QProgressBar::setMaximum);
+    connect(_scanner, &OTMapScanner::statusUpdate, this, &wVerifyMap::onStatusUpdate);
 
     ui->statusbar->addPermanentWidget(ui->pgbProgress);
 
@@ -142,7 +139,6 @@ void wVerifyMap::on_btnStartVerifying_clicked()
     qInfo().noquote() << QString("Map: %1").arg(filehandler.getMapPath());
 
     selectAllAndClear();
-    filehandler.stuffobj.clear();
     ui->pgbProgress->setVisible(true);
 
     _checker->setOmsiDir(set.read("main", "mainDir").toString());

--- a/OTModules/wVerifyMap/wverifymap.cpp
+++ b/OTModules/wVerifyMap/wverifymap.cpp
@@ -214,11 +214,11 @@ void wVerifyMap::onCheckerFinished() {
     ui->wdgHumansOverview->setMissing(_checker->missingHumansCount());
 
     // GLOBAL TEX:
-    ui->wdgTextures->add(filehandler.stuffobj.existing.globalTextures, false);
-    ui->wdgTextures->add(filehandler.stuffobj.missing.globalTextures, true);
+    ui->wdgTextures->add(_scanner->allTextures(), false);
+    ui->wdgTextures->add(_scanner->missingTextures(), true);
     ui->wdgTextures->apply();
-    ui->wdgTexturesOverview->setTotal(ui->wdgTextures->getData().total);
-    ui->wdgTexturesOverview->setMissing(ui->wdgTextures->getData().missing);
+    ui->wdgTexturesOverview->setTotal(_scanner->allTexturesCount());
+    ui->wdgTexturesOverview->setMissing(_scanner->missingTexturesCount());
 
     qInfo() << "Verification finished.";
     ui->statusbar->showMessage(tr("Verification finished."), 5000);

--- a/OTModules/wVerifyMap/wverifymap.cpp
+++ b/OTModules/wVerifyMap/wverifymap.cpp
@@ -241,13 +241,12 @@ void wVerifyMap::loadMapList()
     mapList = filehandler.listMaps();
 
     qDebug().noquote() << "Map count:" << mapList.size();
-
-    for (int i = 0; i < mapList.size(); i++)
-        ui->cobxMapName->addItem(mapList[i].first);
+    QString lastMap = set.read(objectName(), "mapPath").toString();
 
     for (int i = 0; i < mapList.size(); i++)
     {
-        if (mapList[i].second == set.read(objectName(), "mapPath").toString())
+        ui->cobxMapName->addItem(mapList[i].first);
+        if (mapList[i].second == lastMap)
         {
             ui->cobxMapName->setCurrentIndex(i);
             i = mapList.size();

--- a/OTModules/wVerifyMap/wverifymap.cpp
+++ b/OTModules/wVerifyMap/wverifymap.cpp
@@ -207,11 +207,11 @@ void wVerifyMap::onCheckerFinished() {
     ui->wdgVehiclesOverview->setMissing(ui->wdgVehicles->getData().missing);
 
     // HUM:
-    ui->wdgHumans->add(filehandler.stuffobj.existing.humans, false);
-    ui->wdgHumans->add(filehandler.stuffobj.missing.humans, true);
+    ui->wdgHumans->add(_checker->allHumans(), false);
+    ui->wdgHumans->add(_checker->missingHumans(), true);
     ui->wdgHumans->apply();
-    ui->wdgHumansOverview->setTotal(ui->wdgHumans->getData().total);
-    ui->wdgHumansOverview->setMissing(ui->wdgHumans->getData().missing);
+    ui->wdgHumansOverview->setTotal(_checker->allHumansCount());
+    ui->wdgHumansOverview->setMissing(_checker->missingHumansCount());
 
     // GLOBAL TEX:
     ui->wdgTextures->add(filehandler.stuffobj.existing.globalTextures, false);

--- a/OTModules/wVerifyMap/wverifymap.cpp
+++ b/OTModules/wVerifyMap/wverifymap.cpp
@@ -200,11 +200,11 @@ void wVerifyMap::onCheckerFinished() {
     ui->wdgSplinesOverview->setMissing(_checker->missingSplinesCount());
 
     // VEH:
-    ui->wdgVehicles->add(filehandler.stuffobj.existing.vehicles, false);
-    ui->wdgVehicles->add(filehandler.stuffobj.missing.vehicles, true);
+    ui->wdgVehicles->add(_checker->allVehicles(), false);
+    ui->wdgVehicles->add(_checker->missingVehicles(), true);
     ui->wdgVehicles->apply();
-    ui->wdgVehiclesOverview->setTotal(ui->wdgVehicles->getData().total);
-    ui->wdgVehiclesOverview->setMissing(ui->wdgVehicles->getData().missing);
+    ui->wdgVehiclesOverview->setTotal(_checker->allVehiclesCount());
+    ui->wdgVehiclesOverview->setMissing(_checker->missingVehiclesCount());
 
     // HUM:
     ui->wdgHumans->add(_checker->allHumans(), false);

--- a/OTModules/wVerifyMap/wverifymap.h
+++ b/OTModules/wVerifyMap/wverifymap.h
@@ -7,6 +7,7 @@
 #include "OTModules/OTGeneric/wpreferences.h"
 #include "OTModules/OTGeneric/wfeedback.h"
 #include "OTBackend/OCC/OCFS.h"
+#include "OTBackend/OTMapScanner.h"
 #include <QListWidgetItem>
 #include <QKeySequence>
 #include <QKeyEvent>
@@ -33,8 +34,6 @@ private slots:
 
     void on_actionStartVerifying_triggered();
 
-    void reloadProgress();
-
     void on_actionSendFeedback_triggered();
 
     void on_cobxMapName_currentIndexChanged(int index);
@@ -44,6 +43,10 @@ private slots:
     void on_actionBackToHome_triggered();
 
     void on_btnVerificationPreferences_clicked();
+
+    void onScannerFinished();
+    void onCheckerFinished();
+    void onStatusUpdate(int, QString);
 
 signals:
     void backToHome();
@@ -60,18 +63,15 @@ private:
 
     OTOMSIFileHandler filehandler;
 
-    QTimer *watchProgress = new QTimer();
-
-    void startEndWatchProgress(bool state);
-
-    void endVerifying();
-
     void loadMapList();
 
     QList<QPair<QString, QString>> mapList;
 
     bool mapListSetupFinished = false;
     void enableView(bool enable);
+
+    OTMapScanner *_scanner;
+    OTMapChecker *_checker;
 
 };
 


### PR DESCRIPTION
This is a new engine for the wVerifyMap module.
It scans all tiles (including chrono events) for missing objects as splines as well as the ailist.cfg, all parklists and the humans.txt. But the new engine is almost twice as fast as the old one and even a bit faster than BlueSky which was considered the fastest OMSI map checker tool until now.

# How does it work?
The new engine brings two new classes:
- `OTMapScanner`
- `OTMapChecker`
Since both classes inherit from `QThread`, they function as a two thread and work simultaneously.

And this is, how the magic works:
1. Both threads are started at the same time.
2. The first one (the scanner) reads out all important map files (like global.cfg, tiles, ailist.cfg, parklists etc.) and just collects all specified object, spline and vehicle files.
3. It permanently sends new found files to the "checker" thread which saves them in a queue.
4. At the same time while the scanner continues reading files will the thread checker process the queue and create a list of all missing files by just checking if they do exist.
5. At the end if both threads are finished, the checker has both a complete list of all used objects, splines, vehicles etc. and a second one which includes just the missing ones.

I needed to make bigger changes to the wVerifyMap modules .cpp and .h files to get the new engine to work.
As a result of that, maybe there is some code in the `filehandler` class that is completely obsolete now.
But because I don't really know which other modules and classes may use that code as well I decided to leave it there.
But the `filehandler` class definitely should get a big cleanup before the next release because it will have some dead code now for sure. 😂

---

In the future, we will try to integrate the same engine in the cleanup module as well and generalize it to be able to scan multiple maps as well.